### PR TITLE
fixed localisation

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -111,6 +111,7 @@ enum ParameterAddress {
     BURST = 0x2B
 };
 
+//%color=#444444 icon="\uf185" block="SI1151"
 namespace SI1151 {
 
 

--- a/pxt.json
+++ b/pxt.json
@@ -1,6 +1,6 @@
 {
-    "name": "pxt-sunlightsensor-si1151",
-    "description": "",
+    "name": "SI1151",
+    "description": "sunlightsensor Si1151",
     "dependencies": {
         "core": "*"
     },
@@ -8,9 +8,6 @@
         "main.blocks",
         "main.ts",
         "README.md",
-        "test.ts",
-        "_locales/SI1151-strings.json",
-        "_locales/SI1151-jsdoc-strings.json",
         "_locales/de/SI1151-strings.json",
         "_locales/de/SI1151-jsdoc-strings.json"
     ],

--- a/pxt.json
+++ b/pxt.json
@@ -1,5 +1,6 @@
 {
     "name": "SI1151",
+    "version": "0.0.1",
     "description": "sunlightsensor Si1151",
     "dependencies": {
         "core": "*"

--- a/test.ts
+++ b/test.ts
@@ -1,4 +1,3 @@
-
 SI1151.initSunlight()
 basic.forever(function () {
     serial.writeLine("Licht:" + SI1151.getHalfWord_Visible())


### PR DESCRIPTION
Icon und Farbe angepasst,
pxt.json geändert damit Localisation geladen wird

Immer noch Simmerror wenn die Erweiterung in Makecode bearbeitet wird.

![grafik](https://github.com/calliope-edu/pxt-sunlightsensor-si1151/assets/37311672/503474c1-ef86-4586-bc73-efbd12ddcd62)
